### PR TITLE
Add dependency for git-lfs.

### DIFF
--- a/prebuild/requirements.yml
+++ b/prebuild/requirements.yml
@@ -5,3 +5,4 @@
 - src: geerlingguy.docker
 - src: geerlingguy.pip
 - src: geerlingguy.nodejs
+- src: pedrocarmona.github-git-lfs


### PR DESCRIPTION
Hi Jeff et al,

Thanks for the great work, it runs very well indeed. I have the requirement to handle large files using Github's LFS system, and this was the only way I could find to add support. The module relies on your own git playbook. Of course you may not want to add this dependency, but I thought I'd send this PR to see if you would consider adding git-lfs support of some kind.

Cheers!