### PR TITLE
python_ldap package in awx_task container

### DIFF
--- a/prebuild/vars/Debian.yml
+++ b/prebuild/vars/Debian.yml
@@ -4,3 +4,4 @@ awx_package_dependencies:
   - gettext
   - g++
   - bzip2
+  - python-ldap

--- a/prebuild/vars/RedHat.yml
+++ b/prebuild/vars/RedHat.yml
@@ -4,3 +4,4 @@ awx_package_dependencies:
   - gettext
   - gcc-c++
   - bzip2
+  - python-ldap

--- a/prebuild/vars/main.yml
+++ b/prebuild/vars/main.yml
@@ -16,3 +16,6 @@ nodejs_version: "6.x"
 pip_install_packages:
   - name: docker
   - name: docker-compose
+  - name: setuptools
+    state: latest
+  - name: openshift


### PR DESCRIPTION
Ansible has two modules for manipulating ldap repositories; ldap_entry and ldap_attr. The modules requires python_ldap library to be installed on hosts where the modules are used.

It's desirable to have to option the these modules on ansible control hosts, such as inside awx_task container in situations where ansible is used purely for LDAP provisioning.